### PR TITLE
Add proper type guards to backend API requests

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -54,3 +54,9 @@ export async function getScoreCards(userId: string): Promise<ScoreCard[]> {
   console.log({ scoreCards });
   return scoreCards;
 }
+
+// isValidISOString detmines whether the string represents a valid ISO datetime string.
+export const isValidISOString = (datetime: string): boolean => {
+  const date = new Date(datetime);
+  return !isNaN(date.getTime()) && datetime === date.toISOString();
+}

--- a/pages/api/course/index.ts
+++ b/pages/api/course/index.ts
@@ -9,17 +9,18 @@ interface RequestBody {
   state: string;
 }
 
-function isRequestBody(object: any): boolean {
+function isRequestBody(object: unknown): object is RequestBody {
   return (
-    object.name &&
+    typeof object === "object" &&
+    "name" in object &&
     typeof object.name === "string" &&
-    object.lat &&
+    "lat" in object &&
     typeof object.lat === "number" &&
-    object.lon &&
+    "lon" in object &&
     typeof object.lon === "number" &&
-    object.city &&
+    "city" in object &&
     typeof object.city === "string" &&
-    object.state &&
+    "state" in object &&
     typeof object.state === "string"
   );
 }
@@ -33,7 +34,7 @@ export default async function handle(
       return res.status(400).json({ error: "Invalid fields" });
     }
 
-    const { name, lat, lon, city, state } = req.body as RequestBody;
+    const { name, lat, lon, city, state } = req.body;
 
     const sameLocation = await prisma.location.findFirst({
       where: { city: city, state: state },

--- a/pages/api/courses/[courseId]/index.ts
+++ b/pages/api/courses/[courseId]/index.ts
@@ -10,17 +10,18 @@ interface PutBody {
   state: string;
 }
 
-function isPutBody(object: any): boolean {
+function isPutBody(object: unknown): object is PutBody {
   return (
-    object.name &&
+    typeof object === "object" &&
+    "name" in object &&
     typeof object.name === "string" &&
-    object.lat &&
+    "lat" in object &&
     typeof object.lat === "number" &&
-    object.lon &&
+    "lon" in object &&
     typeof object.lon === "number" &&
-    object.city &&
+    "city" in object &&
     typeof object.city === "string" &&
-    object.state &&
+    "state" in object &&
     typeof object.state === "string"
   );
 }
@@ -61,7 +62,7 @@ export default async function handle(
     if (!isPutBody(req.body)) {
       return res.status(400).json({ error: "Invalid input" });
     }
-    const { name, lat, lon, city, state } = req.body as PutBody;
+    const { name, lat, lon, city, state } = req.body;
 
     const sameLocation = await prisma.location.findFirst({
       where: { city: city, state: state },

--- a/pages/api/courses/[courseId]/layout/index.ts
+++ b/pages/api/courses/[courseId]/layout/index.ts
@@ -8,13 +8,14 @@ interface HoleSchema {
   distance: number;
 }
 
-function isHole(object: any): boolean {
+function isHole(object: unknown): object is HoleSchema {
   return (
-    object.number &&
+    typeof object === "object" &&
+    "number" in object &&
     typeof object.number === "number" &&
-    object.par &&
+    "par" in object &&
     typeof object.par === "number" &&
-    object.distance &&
+    "distance" in object &&
     typeof object.distance === "number"
   );
 }
@@ -24,11 +25,12 @@ interface RequestBody {
   holes: Array<HoleSchema>;
 }
 
-function isRequestBody(object: any): boolean {
+function isRequestBody(object: unknown): object is RequestBody {
   return (
-    object.name &&
+    typeof object === "object" &&
+    "name" in object &&
     typeof object.name === "string" &&
-    object.holes &&
+    "holes" in object &&
     object.holes instanceof Array &&
     object.holes.every((hole) => isHole(hole))
   );
@@ -55,7 +57,7 @@ export default async function handle(
       return res.status(400).json({ error: "Invalid input" });
     }
 
-    const { name, holes } = req.body as RequestBody;
+    const { name, holes } = req.body;
 
     const layout = await prisma.layout.create({
       data: {

--- a/pages/api/courses/[courseId]/layouts/[layoutId]/index.ts
+++ b/pages/api/courses/[courseId]/layouts/[layoutId]/index.ts
@@ -8,13 +8,14 @@ interface HoleSchema {
   distance: number;
 }
 
-function isHole(object: any): boolean {
+function isHole(object: unknown): object is HoleSchema {
   return (
-    object.number &&
+    typeof object === "object" &&
+    "number" in object &&
     typeof object.number === "number" &&
-    object.par &&
+    "par" in object &&
     typeof object.par === "number" &&
-    object.distance &&
+    "distance" in object &&
     typeof object.distance === "number"
   );
 }
@@ -24,11 +25,12 @@ interface PutBody {
   holes: Array<HoleSchema>;
 }
 
-function isPutBody(object: any): boolean {
+function isPutBody(object: unknown): object is PutBody {
   return (
-    object.name &&
+    typeof object === "object" &&
+    "name" in object &&
     typeof object.name === "string" &&
-    object.holes &&
+    "holes" in object &&
     object.holes instanceof Array &&
     object.holes.every((hole) => isHole(hole))
   );
@@ -94,7 +96,7 @@ export default async function handle(
       return res.status(400).json({ error: "Invalid input" });
     }
 
-    const { name, holes } = req.body as PutBody;
+    const { name, holes } = req.body;
 
     const updatedLayout = await prisma.layout.update({
       where: { id: layout.id },

--- a/pages/api/login/index.ts
+++ b/pages/api/login/index.ts
@@ -7,12 +7,13 @@ interface LoginBody {
   password: string;
 }
 
-function isLoginBody(obj: any): boolean {
+function isLoginBody(object: unknown): object is LoginBody {
   return (
-    obj.email &&
-    typeof obj.email === "string" &&
-    obj.password &&
-    typeof obj.password === "string"
+    typeof object === "object" &&
+    "email" in object &&
+    typeof object.email === "string" &&
+    "password" in object &&
+    typeof object.password === "string"
   );
 }
 
@@ -27,7 +28,7 @@ export default async function handle(
       });
     }
 
-    const { email, password } = req.body as LoginBody;
+    const { email, password } = req.body;
 
     const user = await prisma.user.findUnique({ where: { email: email } });
     if (!user || !(await passwordMatchesHash(password, user.passwordHash))) {

--- a/pages/api/user/index.ts
+++ b/pages/api/user/index.ts
@@ -10,17 +10,18 @@ interface RequestBody {
   password: string;
 }
 
-function isRequestBody(object: any): boolean {
+function isRequestBody(object: unknown): object is RequestBody {
   return (
-    object.firstName &&
+    typeof object === "object" &&
+    "firstName" in object &&
     typeof object.firstName === "string" &&
-    object.lastName &&
+    "lastName" in object &&
     typeof object.lastName === "string" &&
-    object.email &&
+    "email" in object &&
     typeof object.email === "string" &&
-    object.username &&
+    "username" in object &&
     typeof object.username === "string" &&
-    object.password &&
+    "password" in object &&
     typeof object.password === "string"
   );
 }
@@ -33,8 +34,7 @@ export default async function handle(
     if (!isRequestBody(req.body)) {
       return res.status(400).json({ error: "Invalid input" });
     }
-    const { firstName, lastName, email, username, password } =
-      req.body as RequestBody;
+    const { firstName, lastName, email, username, password } = req.body;
 
     const userWithEmail = await prisma.user.findFirst({
       where: { email: email },

--- a/pages/api/users/[userId]/index.ts
+++ b/pages/api/users/[userId]/index.ts
@@ -8,13 +8,14 @@ interface PutBody {
   email: string;
 }
 
-function isPutBody(object: any): boolean {
+function isPutBody(object: unknown): object is PutBody {
   return (
-    object.firstName &&
+    typeof object === "object" &&
+    "firstName" in object &&
     typeof object.firstName === "string" &&
-    object.lastName &&
+    "lastName" in object &&
     typeof object.lastName === "string" &&
-    object.email &&
+    "email" in object &&
     typeof object.email === "string"
   );
 }
@@ -43,7 +44,7 @@ export default async function handle(
     if (!isPutBody(req.body)) {
       return res.status(400).json({ error: "Invalid input" });
     }
-    const { firstName, lastName, email } = req.body as PutBody;
+    const { firstName, lastName, email } = req.body;
 
     const userWithEmail = await prisma.user.findFirst({
       where: { email: email },

--- a/pages/api/users/[userId]/scores/[scoreId]/index.ts
+++ b/pages/api/users/[userId]/scores/[scoreId]/index.ts
@@ -1,17 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import prisma from "../../../../../../lib/prisma";
-import { getNumericId } from "../../../../../../lib/util";
+import { getNumericId, isValidISOString } from "../../../../../../lib/util";
 
 interface ScoreSchema {
   number: number;
   strokes: number;
 }
 
-function isScore(object: any): boolean {
+function isScore(object: unknown): object is ScoreSchema {
   return (
-    object.number &&
+    typeof object === "object" &&
+    "number" in object &&
     typeof object.number === "number" &&
-    object.strokes &&
+    "strokes" in object &&
     typeof object.strokes === "number"
   );
 }
@@ -23,25 +24,20 @@ interface PutBody {
   scores: Array<ScoreSchema>;
 }
 
-function isPutBody(object: any): boolean {
-  if (
-    !object.courseId ||
-    typeof object.courseId !== "number" ||
-    !object.layoutId ||
-    typeof object.layoutId !== "number" ||
-    !object.datetime ||
-    typeof object.datetime !== "string" ||
-    !(object.scores instanceof Array) ||
-    !object.scores.every((score) => isScore(score))
-  ) {
-    return false;
-  }
-  const date = new Date(object.datetime);
-  if (isNaN(date.getTime()) || object.datetime !== date.toISOString()) {
-    return false;
-  }
-
-  return true;
+function isPutBody(object: unknown): object is PutBody {
+  return (
+    typeof object === "object" &&
+    "courseId" in object &&
+    typeof object.courseId === "number" &&
+    "layoutId" in object &&
+    typeof object.layoutId === "number" &&
+    "datetime" in object &&
+    typeof object.datetime === "string" &&
+    isValidISOString(object.datetime) &&
+    "scores" in object &&
+    object.scores instanceof Array &&
+    object.scores.every((score) => isScore(score))
+  );
 }
 
 export default async function handle(
@@ -107,7 +103,7 @@ export default async function handle(
         .json({ error: "Missing or incorrect body parameters" });
     }
 
-    const { courseId, layoutId, datetime, scores } = req.body as PutBody;
+    const { courseId, layoutId, datetime, scores } = req.body;
 
     const layout = await prisma.layout.findUnique({
       where: { id: layoutId },


### PR DESCRIPTION
This PR adds more thorough type checking for request body types and uses [type guard functions](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards) rather than predicates with casting