### PR TITLE
Use query layer instead of prisma in API handlers

### DIFF
--- a/components/CourseCard.tsx
+++ b/components/CourseCard.tsx
@@ -66,7 +66,7 @@ export default function CourseCard({ course, layouts, scores }: Props) {
             {scores.map((scoreCard) => (
               <li
                 key={
-                  scoreCard.courseId + scoreCard.layoutId + scoreCard.datetime
+                  scoreCard.courseID + scoreCard.layoutID + scoreCard.datetime
                 }
               >
                 <ScoreCardPreview

--- a/components/ScoreCardPreview.tsx
+++ b/components/ScoreCardPreview.tsx
@@ -19,7 +19,7 @@ export default function ScoreCardPreview({
   });
   const month = date.toLocaleString("default", { month: "long" });
   const dateString = `${month} ${date.getDay()}, ${date.getFullYear()} ${time}`;
-  const layout = layouts.find((layout) => layout.id === scoreCard.layoutId);
+  const layout = layouts.find((layout) => layout.id === scoreCard.layoutID);
   const totalPar = layout.holes
     .map((layout) => layout.par)
     .reduce((total, par) => total + par);

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1,0 +1,290 @@
+import prisma from "./prisma";
+import { Course, Hole, Layout } from "./types";
+
+// courseExists determines if the course with the given name and location exists.
+export const courseExists = async (
+  name: string,
+  city: string,
+  state: string
+): Promise<boolean> => {
+  const location = await prisma.location.findFirst({
+    where: { city: city, state: state },
+  });
+  if (location === null) {
+    return false;
+  }
+  const course = await prisma.course.findFirst({
+    where: { name: name, location: location },
+  });
+  return course !== null;
+};
+
+// courseExistsByID determines if a course with the given ID exists.
+export const courseExistsByID = async (courseID: number): Promise<boolean> => {
+  const course = await prisma.course.findUnique({ where: { id: courseID } });
+  return course !== null;
+};
+
+// createCourse creates a course with the given metadata.
+export const createCourse = async (
+  name: string,
+  city: string,
+  state: string,
+  lat: number,
+  lon: number
+): Promise<Course> => {
+  const existingLocation = await prisma.location.findFirst({
+    where: { city: city, state: state },
+  });
+  const location =
+    existingLocation !== null
+      ? existingLocation
+      : await prisma.location.create({
+          data: { lat: lat, lon: lon, city: city, state: state },
+        });
+  const course = await prisma.course.create({
+    data: { name: name, locationId: location.id },
+  });
+  return {
+    id: course.id,
+    name: course.name,
+    city: location.city,
+    state: location.state,
+    lat: location.lat,
+    lon: location.lon,
+  };
+};
+
+// getCourses returns all courses in the database.
+export const getCourses = async (): Promise<Array<Course>> => {
+  const courses = await prisma.course.findMany({
+    include: {
+      location: true,
+    },
+  });
+
+  return courses.map((course) => ({
+    id: course.id,
+    name: course.name,
+    city: course.location.city,
+    state: course.location.state,
+    lat: course.location.lat,
+    lon: course.location.lon,
+  }));
+};
+
+// getCourse returns the data for the course with the same name, city, and state or null if it does not exist.
+export const getCourse = async (
+  name: string,
+  city: string,
+  state: string
+): Promise<Course | null> => {
+  const location = await prisma.location.findFirst({
+    where: { city: city, state: state },
+  });
+  if (!location) {
+    return null;
+  }
+  const course = await prisma.course.findFirst({
+    include: {
+      location: true,
+    },
+    where: { name: name, location: location },
+  });
+  if (!course) {
+    return null;
+  }
+
+  return {
+    id: course.id,
+    name: course.name,
+    city: course.location.city,
+    state: course.location.state,
+    lat: course.location.lat,
+    lon: course.location.lon,
+  };
+};
+
+// getCourse returns the data for the course with the given ID or null if it does not exist.
+export const getCourseByID = async (
+  courseID: number
+): Promise<Course | null> => {
+  const course = await prisma.course.findUnique({
+    include: {
+      location: true,
+    },
+    where: { id: courseID },
+  });
+  if (!course) {
+    return null;
+  }
+
+  return {
+    id: course.id,
+    name: course.name,
+    city: course.location.city,
+    state: course.location.state,
+    lat: course.location.lat,
+    lon: course.location.lon,
+  };
+};
+
+// updateCourse updates the target course with a new name and location information.
+export const updateCourse = async (
+  courseID: number,
+  name: string,
+  city: string,
+  state: string,
+  lat: number,
+  lon: number
+): Promise<Course> => {
+  const course = await prisma.course.update({
+    include: {
+      location: true,
+    },
+    data: {
+      name: name,
+      location: {
+        // Automatically creates new location no matter what, this should change
+        create: {
+          city,
+          state,
+          lat,
+          lon,
+        },
+      },
+    },
+    where: {
+      id: courseID,
+    },
+  });
+
+  return {
+    id: course.id,
+    name: course.name,
+    city: course.location.city,
+    state: course.location.state,
+    lat: course.location.lat,
+    lon: course.location.lon,
+  };
+};
+
+// deleteCourse deletes the course with the given ID.
+export const deleteCourse = async (courseID: number): Promise<void> => {
+  await prisma.course.delete({ where: { id: courseID } });
+};
+
+// layoutExists determines if a layout with the given name exists for the given course.
+export const layoutExists = async (
+  name: string,
+  courseID: number
+): Promise<boolean> => {
+  const layout = await prisma.layout.findFirst({
+    where: { name: name, courseId: courseID },
+  });
+  return layout !== null;
+};
+
+// createLayout creates a course layout with the given name and holes.
+export const createLayout = async (
+  name: string,
+  courseID: number,
+  holes: Array<Hole>
+): Promise<Layout> => {
+  const layout = await prisma.layout.create({
+    include: { holes: true },
+    data: {
+      name: name,
+      courseId: courseID,
+      holes: {
+        create: holes,
+      },
+    },
+  });
+
+  return {
+    id: layout.id,
+    name: layout.name,
+    holes: layout.holes.map((hole) => ({
+      number: hole.number,
+      distance: hole.distance,
+      par: hole.par,
+    })),
+  };
+};
+
+// getLayout returns the data for a layout with the given ID or null if it does not exist.
+export const getLayout = async (layoutID: number): Promise<Layout | null> => {
+  const layout = await prisma.layout.findUnique({
+    where: { id: layoutID },
+    include: { holes: true },
+  });
+  if (!layout) {
+    return null;
+  }
+  return {
+    id: layout.id,
+    name: layout.name,
+    holes: layout.holes.map((hole) => ({
+      number: hole.number,
+      par: hole.par,
+      distance: hole.distance,
+    })),
+  };
+};
+
+// getLayouts returns the data for all layouts for the given course.
+export const getLayouts = async (courseID: number): Promise<Array<Layout>> => {
+  const layouts = await prisma.layout.findMany({
+    where: { courseId: courseID },
+    include: { holes: true },
+  });
+  if (!layouts) {
+    return [];
+  }
+  return layouts.map((layout) => ({
+    id: layout.id,
+    name: layout.name,
+    holes: layout.holes.map((hole) => ({
+      number: hole.number,
+      par: hole.par,
+      distance: hole.distance,
+    })),
+  }));
+};
+
+// updateLayout updates a course layout with the given name and holes.
+export const updateLayout = async (
+  layoutID: number,
+  name: string,
+  holes: Array<Hole>
+): Promise<Layout> => {
+  const layout = await prisma.layout.update({
+    where: { id: layoutID },
+    include: { holes: true },
+    data: {
+      name: name,
+      //TODO: This will create new holes with new IDs and will break scores.
+      // Should switch to having scores be based on layoutID + hole number
+      holes: {
+        deleteMany: { layoutId: layoutID },
+        create: holes,
+      },
+    },
+  });
+
+  return {
+    id: layout.id,
+    name: layout.name,
+    holes: layout.holes.map((hole) => ({
+      number: hole.number,
+      distance: hole.distance,
+      par: hole.par,
+    })),
+  };
+};
+
+// deleteLayout deletes the layout with the given ID.
+export const deleteLayout = async (layoutID: number): Promise<void> => {
+  await prisma.layout.delete({ where: { id: layoutID } });
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,14 +19,30 @@ export interface Hole {
   distance: number;
 }
 
+export interface UserAuth {
+  id: number;
+  username: string;
+  email: string;
+  passwordHash: string;
+}
+
+export interface User {
+  id: number;
+  username: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+}
+
 export interface Score {
   number: number;
   strokes: number;
 }
 
 export interface ScoreCard {
-  courseId: number;
-  layoutId: number;
+  id: number;
   datetime: string;
+  courseID: number;
+  layoutID: number;
   scores: Array<Score>;
 }

--- a/pages/api/login/index.ts
+++ b/pages/api/login/index.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "../../../lib/prisma";
 import { passwordMatchesHash, getJWT } from "../../../lib/auth";
 import * as http from "../../../lib/http";
+import * as queries from "../../../lib/queries";
 
 interface LoginBody {
   email: string;
@@ -25,6 +25,7 @@ export default async function handle(
   switch (req.method) {
     case http.Methods.Post: {
       if (!isLoginBody(req.body)) {
+        console.log("Failed to parse request body", req.body);
         return res.status(http.Statuses.BadRequest).json({
           error: "Invalid input",
         });
@@ -32,21 +33,34 @@ export default async function handle(
 
       const { email, password } = req.body;
 
-      const user = await prisma.user.findUnique({ where: { email: email } });
-      if (!user || !(await passwordMatchesHash(password, user.passwordHash))) {
-        console.log(`Failed to authenticate user: ${email}`);
-        return res.status(http.Statuses.BadRequest).end();
+      try {
+        const user = await queries.getUserAuth(email);
+
+        if (
+          !user ||
+          !(await passwordMatchesHash(password, user.passwordHash))
+        ) {
+          console.log(`Failed to authenticate user: ${email}`);
+          return res.status(http.Statuses.BadRequest).end();
+        }
+
+        console.log(`Authenticated user ${user.email}`);
+
+        const jwt = getJWT({ id: user.id, username: user.username });
+
+        return res.status(http.Statuses.OK).json({
+          username: user.username,
+          token: jwt,
+        });
+      } catch (err) {
+        console.error("failed user login process", err);
+        return res
+          .status(http.Statuses.InternalServerError)
+          .json({ error: "failed user login process" });
       }
-      console.log(`Authenticated user ${user.email}`);
-
-      const jwt = getJWT({ id: user.id, username: user.username });
-
-      return res.status(http.Statuses.OK).json({
-        username: user.username,
-        token: jwt,
-      });
     }
     default: {
+      console.log(`Unsupported method ${req.method} for path ${req.url}`);
       return res.status(http.Statuses.NotFound).end();
     }
   }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,13 +45,12 @@ model Layout {
 }
 
 model Hole {
-  id       Int     @id @default(autoincrement())
+  id       Int    @id @default(autoincrement())
   number   Int
   par      Int
   distance Int
-  layout   Layout  @relation(fields: [layoutId], references: [id])
+  layout   Layout @relation(fields: [layoutId], references: [id])
   layoutId Int
-  scores   Score[]
 }
 
 model ScoreCard {
@@ -66,9 +65,8 @@ model ScoreCard {
 
 model Score {
   id          Int       @id @default(autoincrement())
+  number      Int
   strokes     Int
-  hole        Hole      @relation(fields: [holeId], references: [id])
-  holeId      Int
   scoreCard   ScoreCard @relation(fields: [scoreCardId], references: [id])
   scoreCardId Int
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -97,39 +97,39 @@ async function seed() {
             scores: {
               create: [
                 {
-                  holeId: 1,
+                  number: 1,
                   strokes: 3,
                 },
                 {
-                  holeId: 2,
+                  number: 2,
                   strokes: 2,
                 },
                 {
-                  holeId: 3,
+                  number: 3,
                   strokes: 3,
                 },
                 {
-                  holeId: 4,
+                  number: 4,
                   strokes: 4,
                 },
                 {
-                  holeId: 5,
+                  number: 5,
                   strokes: 3,
                 },
                 {
-                  holeId: 6,
+                  number: 6,
                   strokes: 3,
                 },
                 {
-                  holeId: 7,
+                  number: 7,
                   strokes: 3,
                 },
                 {
-                  holeId: 8,
+                  number: 8,
                   strokes: 1,
                 },
                 {
-                  holeId: 9,
+                  number: 9,
                   strokes: 3,
                 },
               ],


### PR DESCRIPTION
Rather than using `prisma` directly in API handlers, this PR will factor out prisma into a `queries` library to abstract away from the database layer.